### PR TITLE
Compatibility with ES 7 total hits

### DIFF
--- a/src/ElasticsearchDataSource.php
+++ b/src/ElasticsearchDataSource.php
@@ -54,7 +54,7 @@ final class ElasticsearchDataSource extends FilterableDataSource implements IDat
 	{
 		$searchResult = $this->client->search($this->searchParamsBuilder->buildParams());
 
-		return $searchResult['hits']['total'];
+		return is_array($searchResult['hits']['total']) ? $searchResult['hits']['total']['value'] : $searchResult['hits']['total'];
 	}
 
 


### PR DESCRIPTION
Due to changes in ES7 https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#_literal_hits_total_literal_is_now_an_object_in_the_search_response total hits can be int or array with count of hits in "value" key.